### PR TITLE
Fix submitting for review not working

### DIFF
--- a/lib/fastlane/plugin/huawei_appgallery_connect/actions/huawei_appgallery_connect_submit_for_review.rb
+++ b/lib/fastlane/plugin/huawei_appgallery_connect/actions/huawei_appgallery_connect_submit_for_review.rb
@@ -88,6 +88,12 @@ module Fastlane
                                          description: "Release time in UTC format for app release on a specific date. The format is yyyy-MM-dd'T'HH:mm:ssZZ)",
                                          optional: true,
                                          conflicting_options: [:phase_wise_release],
+                                         type: String),
+          
+            FastlaneCore::ConfigItem.new(key: :changelog_path,
+                                         env_name: "HUAWEI_APPGALLERY_CONNECT_CHANGELOG_PATH",
+                                         description: "Path to Changelog file (Default empty)",
+                                         optional: true,
                                          type: String)
         ]
       end


### PR DESCRIPTION
Action `huawei_appgallery_connect_submit_for_review` was accessing `changelog` so maybe this is why `fastlane` was crashing :) anyway, it works with this fix