### PR TITLE
Add Content-Type to requests that require a JSON body

### DIFF
--- a/lib/fastlane/plugin/huawei_appgallery_connect/helper/huawei_appgallery_connect_helper.rb
+++ b/lib/fastlane/plugin/huawei_appgallery_connect/helper/huawei_appgallery_connect_helper.rb
@@ -57,6 +57,7 @@ module Fastlane
         request = Net::HTTP::Put.new(uri.request_uri)
         request["client_id"] = client_id
         request["Authorization"] = "Bearer #{token}"
+        request["Content-Type"] = "application/json"
 
         request.body = {privacyPolicy: privacy_policy_url}.to_json
 
@@ -96,6 +97,7 @@ module Fastlane
         request = Net::HTTP::Get.new(uri.request_uri)
         request["client_id"] = client_id
         request["Authorization"] = "Bearer #{token}"
+        request["Content-Type"] = "application/json"
 
         response = http.request(request)
 
@@ -143,7 +145,7 @@ module Fastlane
             request = Net::HTTP::Put.new(uri.request_uri)
             request["client_id"] = client_id
             request["Authorization"] = "Bearer #{token}"
-            request['Content-Type'] = "application/json"
+            request["Content-Type"] = "application/json"
 
             data = {fileType: 5, files: [{
 
@@ -251,6 +253,7 @@ module Fastlane
         request = Net::HTTP::Post.new(uri.request_uri)
         request["client_id"] = params[:client_id]
         request["Authorization"] = "Bearer #{token}"
+        request["Content-Type"] = "application/json"
 
         if params[:phase_wise_release] != nil && params[:phase_wise_release]
           request.body = {
@@ -287,4 +290,3 @@ module Fastlane
     end
   end
 end
-


### PR DESCRIPTION
Hello!

I've been testing the plugin and it worked great for uploading an app version to AppGallery. However I found problems when updating a release with the `huawei_appgallery_connect_submit_for_review`.

Apparently the parameters sent to the AppGallery were correct but it didn't work for me, while it worked with the same parameters and request body testing against the API directly with Postman. I saw that Postman added the `Content-Type: application/json` header to the request and adding it to the request for that action made it work, so I added said header in all requests that send a JSON body to ensure that the requests' body are properly read by the API.